### PR TITLE
Prepare release (#5905)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,16 +1,21 @@
 Revision history for SPIRV-Tools
 
-v2024.4 2024-09-19
+v2024.4 2024-12-04
   - General
     - Add FPEncoding operand type. (#5726)
     - Support SPV_KHR_untyped_pointers (#5736)
     - add support for SPV_INTEL_global_variable_host_access (#5786)
+    - Add support for SPV_KHR_compute_shader_derivative (#5817)
+    - Accept hex representation as binary input (#5870)
+    - Vulkan 1.4 support (#5899)
   - Optimizer
     - Add knowledge of cooperative matrices (#5720)
     - Add struct-packing pass and unit test. (#5778)
   - Validator
     - Validate presence of Stride operand to OpCooperativeMatrix{Load,Store}KHR (#5777)
     - Update sampled image validation (#5789)
+    - Disallow stores according to VUID 06924 (#5368)
+    - Add validation for SPV_NV_tensor_addressing and SPV_NV_cooperative_matrix2 (#5865)
   - Linker
     - allow linking functions with different pointer arguments (#5534)
 

--- a/DEPS
+++ b/DEPS
@@ -3,7 +3,7 @@ use_relative_paths = True
 vars = {
   'github': 'https://github.com',
 
-  'abseil_revision': 'c7cf999bda8390d2dd294ef903716a80135e6f4c',
+  'abseil_revision': '7316f5616bad0a794b2a75901cc20b0099718085',
 
   'effcee_revision': '2c97e5689ed8d7ab6ae5820f884f03a601ae124b',
 
@@ -14,7 +14,7 @@ vars = {
 
   're2_revision': '6dcd83d60f7944926bfd308cc13979fc53dd69ca',
 
-  'spirv_headers_revision': '36d5e2ddaa54c70d2f29081510c66f4fc98e5e53',
+  'spirv_headers_revision': '3f17b2af6784bfa2c5aa5dbb8e0e74a607dd8b3b',
 }
 
 deps = {


### PR DESCRIPTION
This is the second release candidate for v2024.4. Includes new commits since September, including Vulkan 1.4 support.